### PR TITLE
(Refactor) Fixes project and module URL

### DIFF
--- a/bunapp/router.go
+++ b/bunapp/router.go
@@ -3,7 +3,7 @@ package bunapp
 import (
 	"net/http"
 
-	"github.com/uptrace/bun-starter-kit/httputil/httperror"
+	"github.com/go-bun/bun-starter-kit/httputil/httperror"
 	"github.com/uptrace/bunrouter"
 	"github.com/uptrace/bunrouter/extra/bunrouterotel"
 	"github.com/uptrace/bunrouter/extra/reqlog"

--- a/cmd/bun/main.go
+++ b/cmd/bun/main.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/uptrace/bun-starter-kit/bunapp"
-	"github.com/uptrace/bun-starter-kit/cmd/bun/migrations"
-	_ "github.com/uptrace/bun-starter-kit/example"
-	"github.com/uptrace/bun-starter-kit/httputil"
+	"github.com/go-bun/bun-starter-kit/bunapp"
+	"github.com/go-bun/bun-starter-kit/cmd/bun/migrations"
+	_ "github.com/go-bun/bun-starter-kit/example"
+	"github.com/go-bun/bun-starter-kit/httputil"
 	"github.com/uptrace/bun/migrate"
 
 	"github.com/urfave/cli/v2"

--- a/cmd/bun/migrations/20210505110026_init.go
+++ b/cmd/bun/migrations/20210505110026_init.go
@@ -3,9 +3,9 @@ package migrations
 import (
 	"context"
 
+	"github.com/go-bun/bun-starter-kit/bunapp"
+	"github.com/go-bun/bun-starter-kit/example"
 	"github.com/uptrace/bun"
-	"github.com/uptrace/bun-starter-kit/bunapp"
-	"github.com/uptrace/bun-starter-kit/example"
 	"github.com/uptrace/bun/dbfixture"
 )
 

--- a/example/init.go
+++ b/example/init.go
@@ -3,7 +3,7 @@ package example
 import (
 	"context"
 
-	"github.com/uptrace/bun-starter-kit/bunapp"
+	"github.com/go-bun/bun-starter-kit/bunapp"
 )
 
 func init() {

--- a/example/org_handler.go
+++ b/example/org_handler.go
@@ -3,7 +3,7 @@ package example
 import (
 	"net/http"
 
-	"github.com/uptrace/bun-starter-kit/bunapp"
+	"github.com/go-bun/bun-starter-kit/bunapp"
 	"github.com/uptrace/bunrouter"
 )
 

--- a/example/org_handler_test.go
+++ b/example/org_handler_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-bun/bun-starter-kit/example"
+	"github.com/go-bun/bun-starter-kit/testbed"
 	"github.com/stretchr/testify/require"
-	"github.com/uptrace/bun-starter-kit/example"
-	"github.com/uptrace/bun-starter-kit/testbed"
 )
 
 func TestOrgHandler(t *testing.T) {

--- a/example/user_handler.go
+++ b/example/user_handler.go
@@ -3,7 +3,7 @@ package example
 import (
 	"net/http"
 
-	"github.com/uptrace/bun-starter-kit/bunapp"
+	"github.com/go-bun/bun-starter-kit/bunapp"
 	"github.com/uptrace/bunrouter"
 )
 

--- a/example/user_handler_test.go
+++ b/example/user_handler_test.go
@@ -4,10 +4,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-bun/bun-starter-kit/bunapp"
+	"github.com/go-bun/bun-starter-kit/example"
+	"github.com/go-bun/bun-starter-kit/testbed"
 	"github.com/stretchr/testify/require"
-	"github.com/uptrace/bun-starter-kit/bunapp"
-	"github.com/uptrace/bun-starter-kit/example"
-	"github.com/uptrace/bun-starter-kit/testbed"
 	"github.com/uptrace/bun/dbfixture"
 )
 

--- a/example/welcome_handler.go
+++ b/example/welcome_handler.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"text/template"
 
-	"github.com/uptrace/bun-starter-kit/bunapp"
+	"github.com/go-bun/bun-starter-kit/bunapp"
 	"github.com/uptrace/bunrouter"
 )
 

--- a/example/welcome_handler_test.go
+++ b/example/welcome_handler_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-bun/bun-starter-kit/example"
+	"github.com/go-bun/bun-starter-kit/testbed"
 	"github.com/stretchr/testify/require"
-	"github.com/uptrace/bun-starter-kit/example"
-	"github.com/uptrace/bun-starter-kit/testbed"
 )
 
 func TestWelcomeHandler(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/uptrace/bun-starter-kit
+module github.com/go-bun/bun-starter-kit
 
 go 1.16
 

--- a/testbed/testbed.go
+++ b/testbed/testbed.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-bun/bun-starter-kit/bunapp"
 	"github.com/stretchr/testify/require"
-	"github.com/uptrace/bun-starter-kit/bunapp"
 	"github.com/uptrace/bunrouter"
 )
 


### PR DESCRIPTION
I could not use the CLI tool because the project was moved, that's why I refactored the Module URL and the imports